### PR TITLE
Fix: using content-length to read the body and optimised handling socket input streams

### DIFF
--- a/src/fullstackclj/backend/helpers/http.clj
+++ b/src/fullstackclj/backend/helpers/http.clj
@@ -3,23 +3,19 @@
 
 (def method_regx #"(?i)(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE|CONNECT)")
 (def http_vers_regx #"(?i)(?:HTTP)\/\d\.\d")
-(def body_regx #"\r\n\r\n")
-(def crlf_regx #"\r\n")
 
 (defn parse
   "Parses an http request
    
+   request: a vector consisting of http request parameters
    returns: a map of http request elements"
   [request]
-  (let [lines (str/split request body_regx)
-        raw_req_header (str/split (first lines) crlf_regx)
-        req_line (first raw_req_header)
-
+  (let [req_line (first request)
         method (re-find method_regx req_line)
         url (second (str/split req_line #"\s"))
         http_vers (re-find http_vers_regx req_line)
-        headers (rest raw_req_header)
-        body (second lines)]
+        headers (second request)
+        body (peek request)]
     {:method method :url url :http_vers http_vers
      :headers headers
      :body body}))
@@ -31,5 +27,6 @@
         crlf "\r\n"
         headers (assoc headers "Content-Length" (count (or body "")))]
     (str http_vers space status_code space status_info crlf
-         (apply str (map #(str (key %) ": " (val %) crlf) headers)) crlf
+         (apply str (map #(str (key %) ": " (val %) crlf) headers))
+         crlf
          (if (nil? body) "" (str body crlf)))))

--- a/src/fullstackclj/backend/server.clj
+++ b/src/fullstackclj/backend/server.clj
@@ -10,16 +10,21 @@
   [client-socket]
   (with-open [in (BufferedReader. (InputStreamReader. (.getInputStream client-socket)))
               out (PrintWriter. (.getOutputStream client-socket) true)]
-    (let [crlf "\r\n"
-          request (loop [line (.readLine in) message []]
-                    (if (or (nil? line) (empty? line)) message
-                        (recur (.readLine in) (conj message (str line crlf)))))]
-      (println (http/parse (str/join request))))
+    (let [req_line (.readLine in)
+          headers (loop [lines (.readLine in) header {}]
+                    (let [header_kv (str/split lines #":\s")]
+                      (if (or (nil? lines) (empty? lines)) header
+                          (recur (.readLine in) (assoc header (str/lower-case (first header_kv)) (last header_kv))))))
+          content_len (Integer/parseInt (get headers "content-length"))
+          body (char-array content_len)]
+      (.read in body 0 content_len)
+      (println (http/parse [req_line headers (String. body)])))
     (.println out (http/response {:http_vers "HTTP/1.1"
                                   :status_code 200
                                   :status_info "SUCCESS"
                                   :headers {"Content-Length" 0}
-                                  :body "some data"}))))
+                                  :body "some data"}))
+    (.flush out)))
 
 (defn start-server
   "Start the server"

--- a/test/fullstackclj/backend/http_test.clj
+++ b/test/fullstackclj/backend/http_test.clj
@@ -9,8 +9,8 @@
 
 (deftest http-test-parser
   (testing "Parser, Should return a map of the http request as: {:method :url :http_vers :headers :body}")
-  (is (= true (map? (parse "GET / "))))
-  (is (= true (contains_http_params? (parse "GET / \r\na:s\r\nb:q\r\n\r\nbody"))))
+  (is (= true (map? (parse ["GET / "]))))
+  (is (= true (contains_http_params? (parse ["GET / " {:a "s", :b "q"} "body"]))))
   (is (= true (has-key-values? (parse (get-in parser_test_data [:case1 :req]))
                                (get-in parser_test_data [:case1 :res])))))
 

--- a/test/fullstackclj/backend/mock_data.clj
+++ b/test/fullstackclj/backend/mock_data.clj
@@ -1,10 +1,10 @@
 (ns fullstackclj.backend.mock-data)
 (def parser_test_data
-  {:case1 {:req "GET / http/1.1\r\na: s\r\nb: q\r\n\r\nbody"
+  {:case1 {:req ["GET / http/1.1" {"a: s", "b: q"} "body"]
            :res {:method "GET"
                  :url "/"
                  :http_vers "http/1.1"
-                 :headers ["a: s" "b: q"]
+                 :headers {"a: s", "b: q"}
                  :body "body"}}})
 
 (def response_test_data


### PR DESCRIPTION
# Info
## Fix
- body was not parsed correctly, it has been fixed
## Improvement
- optimised handling input streams by rearranging some function calls and using `BufferedReader.read` to read the remainder of the body

# Testing
- Unit tests were updated accordingly